### PR TITLE
Refactor styles and move imageForMobile back to section tags

### DIFF
--- a/general.css
+++ b/general.css
@@ -57,3 +57,15 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+@media screen and (max-width: 700px) {
+  .menu {
+    line-height:14px;
+    right: 10px;
+  }
+  .menu a {
+    font-size: 20px;
+    color: black;
+    opacity: 0.7;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
       <section class="row tall blog1 section imageforMobile">
-          <img class="imageforMobile" src="http://rlwphoto.com/wp-content/uploads/2013/11/Fisher-Towers-Susnet.jpg" />
+          <img src="http://rlwphoto.com/wp-content/uploads/2013/11/Fisher-Towers-Susnet.jpg" />
       </section>
 
 
@@ -49,7 +49,7 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
       <section class="row tall blog2 section imageforMobile">
-          <img class="imageforMobile" src="http://www.onthegotours.com/blog/wp-content/uploads/2011/06/jiuzhaigou-water.jpg" />
+          <img src="http://www.onthegotours.com/blog/wp-content/uploads/2011/06/jiuzhaigou-water.jpg" />
       </section>
 
       <section class="row tall blog3 section" id="third">
@@ -59,7 +59,7 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
       <section class="row tall blog3 section imageforMobile">
-        <img class="imageforMobile" src="http://66.media.tumblr.com/f1f4d5b747285ae007790266e6e2abbb/tumblr_mhqh52JcPe1qc6zpdo1_1280.jpg" />
+        <img src="http://66.media.tumblr.com/f1f4d5b747285ae007790266e6e2abbb/tumblr_mhqh52JcPe1qc6zpdo1_1280.jpg" />
       </section>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -37,8 +37,8 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
-      <section class="row tall blog1 section">
-          <img class="imageforMobile" src="http://rlwphoto.com/wp-content/uploads/2013/11/Fisher-Towers-Susnet.jpg" />
+      <section class="row tall blog1 section imageforMobile">
+          <img src="http://rlwphoto.com/wp-content/uploads/2013/11/Fisher-Towers-Susnet.jpg" />
       </section>
 
 
@@ -48,8 +48,8 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
-      <section class="row tall blog2 section">
-          <img class="imageforMobile" src="http://www.onthegotours.com/blog/wp-content/uploads/2011/06/jiuzhaigou-water.jpg" />
+      <section class="row tall blog2 section imageforMobile">
+          <img src="http://www.onthegotours.com/blog/wp-content/uploads/2011/06/jiuzhaigou-water.jpg" />
       </section>
 
       <section class="row tall blog3 section" id="third">
@@ -58,8 +58,8 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
-      <section class="row tall blog3 section">
-        <img class="imageforMobile" src="http://66.media.tumblr.com/f1f4d5b747285ae007790266e6e2abbb/tumblr_mhqh52JcPe1qc6zpdo1_1280.jpg" />
+      <section class="row tall blog3 section imageforMobile">
+        <img src="http://66.media.tumblr.com/f1f4d5b747285ae007790266e6e2abbb/tumblr_mhqh52JcPe1qc6zpdo1_1280.jpg" />
       </section>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
           <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
       <section class="row tall blog1 section imageforMobile">
-          <img src="http://rlwphoto.com/wp-content/uploads/2013/11/Fisher-Towers-Susnet.jpg" />
+          <img class="imageforMobile" src="http://rlwphoto.com/wp-content/uploads/2013/11/Fisher-Towers-Susnet.jpg" />
       </section>
 
 
@@ -49,7 +49,7 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
       <section class="row tall blog2 section imageforMobile">
-          <img src="http://www.onthegotours.com/blog/wp-content/uploads/2011/06/jiuzhaigou-water.jpg" />
+          <img class="imageforMobile" src="http://www.onthegotours.com/blog/wp-content/uploads/2011/06/jiuzhaigou-water.jpg" />
       </section>
 
       <section class="row tall blog3 section" id="third">
@@ -59,7 +59,7 @@
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum."</p>
       </section>
       <section class="row tall blog3 section imageforMobile">
-        <img src="http://66.media.tumblr.com/f1f4d5b747285ae007790266e6e2abbb/tumblr_mhqh52JcPe1qc6zpdo1_1280.jpg" />
+        <img class="imageforMobile" src="http://66.media.tumblr.com/f1f4d5b747285ae007790266e6e2abbb/tumblr_mhqh52JcPe1qc6zpdo1_1280.jpg" />
       </section>
 
     </div>

--- a/styles.css
+++ b/styles.css
@@ -9,15 +9,17 @@ p, h2 {
 p {
   font-size: 100%;
   margin-top: 2vw;
+  border: 1px dotted green;
 }
 
-p:fist {
+p:first {
   margin-top: 0;
 }
 
 h2 {
   margin-top: 3vw;
   margin-bottom: 3vw;
+  border: 1px dashed red;
 }
 
 .fullWidth {
@@ -150,9 +152,9 @@ section {
   background-repeat: repeat;
 }*/
 
-#fourth p, #seventh p{
+/*#fourth p, #seventh p{
   color: rgb(50,50,50);
-}
+}*/
 
 section h1 {
   text-align: center;

--- a/styles.css
+++ b/styles.css
@@ -199,4 +199,9 @@ img {
       height: 100%;
       width: 100%;
     }
+    .imageforMobile img {
+      display: block;
+      height: 100%;
+      width: 100%;      
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -202,6 +202,11 @@ img {
     .imageforMobile img {
       display: block;
       height: 100%;
-      width: 100%;      
+      width: 100%;
+    }
+    p {
+      padding-left:5vw;
+      padding-right:5vw;
+      font-size:12px;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -9,7 +9,6 @@ p, h2 {
 p {
   font-size: 100%;
   margin-top: 2vw;
-  border: 1px dotted green;
 }
 
 p:first {
@@ -19,7 +18,6 @@ p:first {
 h2 {
   margin-top: 3vw;
   margin-bottom: 3vw;
-  border: 1px dashed red;
 }
 
 .fullWidth {
@@ -152,9 +150,9 @@ section {
   background-repeat: repeat;
 }*/
 
-/*#fourth p, #seventh p{
+#fourth p, #seventh p{
   color: rgb(50,50,50);
-}*/
+}
 
 section h1 {
   text-align: center;


### PR DESCRIPTION
FIX: sections were extra long, which was being caused by the hidden sections used for mobile. Solved by moving those classes from images to section tags.

ISSUE: not sure if this breaks anything that led to the initial move from section to img tags
